### PR TITLE
Bump numba from version 0.55.1 to 0.55.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ joblib==1.2.0
 kiwisolver==1.4.2
 llvmlite==0.38.0
 matplotlib==3.5.1
-numba==0.55.1
+numba==0.55.2
 numpy==1.22.0
 packaging==21.3
 pandas==1.3.5


### PR DESCRIPTION
numba 0.55.1 requires numpy<1.22.0 which is the required version in requirements.txt.
numba 0.55.2 requires nupmy<1.23.0 and makes the overall requirements file non-conflicting